### PR TITLE
handle WriteStream error correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,15 +89,14 @@ var HtmlReporter = function(baseReporterDecorator, config, emitter, logger, help
 			
 			helper.mkdirIfNotExists(path.dirname(reportFile), function() {
 
-				writeStream = fs.createWriteStream(reportFile, function(err) {
-					if (err) {
-						log.warn('Cannot write HTML Report\n\t' + err.message);
-					} else {
-						log.debug('HTML report written to "%s".', reportFile);
-					}
+				writeStream = fs.createWriteStream(reportFile);
+
+				writeStream.on('error', function(err) {
+					log.warn('Cannot write HTML Report\n\t' + err.message);
 				});
 
 				writeStream.on('finish', function() {
+					log.debug('HTML report written to "%s".', reportFile);
 					if (!--pendingFileWritings) {
 						fileWritingFinished();
 					}


### PR DESCRIPTION
fs.createWriteStream does not support callback and io.js throws in this case from v2.3.0